### PR TITLE
fix(benchmark-launcher): Google API chat path is malformed (+3 more)

### DIFF
--- a/fv_eval/benchmark_launcher.py
+++ b/fv_eval/benchmark_launcher.py
@@ -156,7 +156,6 @@ class BenchmarkLauncher(object):
                     full_model_name = "gpt-4-0613"
                 elif "gpt-3.5-turbo" in model_name:
                     full_model_name = "gpt-3.5-turbo-0125"
-                    full_model_name = model_name
                 else:
                     raise ValueError(f"Unknown OpenAI model: {model_name}")
             else:
@@ -222,7 +221,7 @@ class BenchmarkLauncher(object):
         else:
             top_p = 0.95
         
-        while num_retries <= 20:
+        while num_retries <= max_retries:
             try:
                 if (
                     api_provider == "vllm"
@@ -243,7 +242,7 @@ class BenchmarkLauncher(object):
                     time.sleep(5)
                     return [choice.message.content for choice in completion.choices]
                 elif api_provider == "anthropic":
-                    completion = Anthropic().messages.create(
+                    completion = self.chat_client.messages.create(
                         model=model_name,
                         system=system_prompt,
                         messages=[
@@ -254,13 +253,14 @@ class BenchmarkLauncher(object):
                     )
                     time.sleep(10)
                     return [textblock.text for textblock in completion.content]
-                elif api_provider == "google":      
+                elif api_provider == "google":
+                    chat = self.chat_client.start_chat(
                         history=[
                             {"role": "user", "parts": system_prompt},
                             {"role": "model", "parts": "Understood."},
                         ]
                     )
-                    
+
                     completion = chat.send_message(
                         user_prompt,
                         generation_config=google.generativeai.types.GenerationConfig(


### PR DESCRIPTION
Small fixes in `fv_eval/benchmark_launcher.py`:

#### fix: Google API chat path is malformed and missing chat init

**Fix:** Replace:
```
                elif api_provider == "google":      
                        history=[
                            {"role": "user", "parts": system_prompt},
                            {"role": "model", "parts": "Understood."},
                        ]
                    )
                    
                    completion = chat.send_message(
                        user_prompt,
                        generation_config=google.generativeai.types.GenerationConfig(
                            candidate_count=1,
                            max_output_tokens=max_tokens,
                            temperature=temperature,
                        ),
                    )
```

with:
```
                elif api_provider == "google":
                    chat = self.chat_client.start_chat(
                        history=[
                            {"role": "user", "parts": system_prompt},
                            {"role": "model", "parts": "Understood."},
                        ]
                    )

                    completion = chat.send_message(
                        user_prompt,
                        generation_config=google.generativeai.types.GenerationConfig(
                            candidate_count=1,
                            max_output_tokens=max_tokens,
                            temperature=temperature,
                        ),
                    )
```

#### fix: Anthropic path creates new client ignoring configured key/url

**Fix:** Replace:
```
                elif api_provider == "anthropic":
                    completion = Anthropic().messages.create(
                        model=model_name,
                        system=system_prompt,
                        messages=[
                            {"role": "user", "content": user_prompt},
                        ],
                        max_tokens=max_tokens,
                        temperature=temperature,
                    )
```

with:
```
                elif api_provider == "anthropic":
                    completion = self.chat_client.messages.create(
                        model=model_name,
                        system=system_prompt,
                        messages=[
                            {"role": "user", "content": user_prompt},
                        ],
                        max_tokens=max_tokens,
                        temperature=temperature,
                    )
```

#### fix: Retry loop hardcoded to 20 instead of using max_retries

**Fix:** Replace:
```
        while num_retries <= 20:
            try:
```

with:
```
        while num_retries <= max_retries:
            try:
```

#### fix: gpt-3.5-turbo resolved name is immediately overwritten

**Fix:** Replace:
```
                elif "gpt-3.5-turbo" in model_name:
                    full_model_name = "gpt-3.5-turbo-0125"
                    full_model_name = model_name
```

with:
```
                elif "gpt-3.5-turbo" in model_name:
                    full_model_name = "gpt-3.5-turbo-0125"
```

### Files changed
- `fv_eval/benchmark_launcher.py`