### PR TITLE
fix: --temperature argument is parsed but never used

### DIFF
--- a/run_nl2sva.py
+++ b/run_nl2sva.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     timestamp_str = datetime.now().strftime("%Y%m%d%H")
-    temperature = 0.0
+    temperature = args.temperature
 
     if args.debug:
         print("Executing in debug mode")


### PR DESCRIPTION
### Problem
fix: --temperature argument is parsed but never used

### Fix
Replace:
```
    args = parser.parse_args()
    timestamp_str = datetime.now().strftime("%Y%m%d%H")
    temperature = 0.0

    if args.debug:
```

with:
```
    args = parser.parse_args()
    timestamp_str = datetime.now().strftime("%Y%m%d%H")
    temperature = args.temperature

    if args.debug:
```

### Files changed
- `run_nl2sva.py`